### PR TITLE
feat: allow slugs in links to be replaceable

### DIFF
--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -87,8 +87,15 @@ class Breadcrumb
 
         // Loop through each link in the $this->links array by reference to modify the original array
         foreach ($this->links as &$link) {
-            // Replace when link text is numeric or in special words
-            if (is_numeric($link['text']) || isset($specialWordsFlipped[$link['text']])) {
+            // Replace when link text is numeric, in special words, or matches the 'Breadcrumb.' slug pattern
+            if (is_numeric($link['text']) || isset($specialWordsFlipped[$link['text']]) || preg_match('/^Breadcrumb\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $link['text'])) {
+                $link['text'] = array_shift($newParams);
+
+                // Guard clause when no new parameters available
+                if ($newParams === []) {
+                    break;
+                }
+            }
                 $link['text'] = array_shift($newParams);
 
                 // Guard clause when no new parameters available

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -96,13 +96,6 @@ class Breadcrumb
                     break;
                 }
             }
-                $link['text'] = array_shift($newParams);
-
-                // Guard clause when no new parameters available
-                if ($newParams === []) {
-                    break;
-                }
-            }
         }
     }
 


### PR DESCRIPTION
This change updates the condition for replacing breadcrumb link text. It now replaces the text if it meets any of the following criteria:

The text is numeric.
The text matches a predefined list of special words.
The text follows the pattern 'Breadcrumb.' followed by one or more alphanumeric characters, which can optionally be separated by hyphens.

The slug pattern described in the PHP code snippet is designed to match strings that begin with "Breadcrumb." followed by one or more alphanumeric characters (letters a-z and numbers 0-9). These alphanumeric characters can optionally be separated by hyphens. Here's a breakdown of the pattern:

- ^Breadcrumb\.: This part matches the beginning of the string, ensuring it starts with "Breadcrumb.". The backslash before the period is used to escape the period character, as it has a special meaning in regular expressions (it usually matches any single character).
- [a-z0-9]+: This part matches one or more alphanumeric characters immediately following "Breadcrumb.".
- (?:-[a-z0-9]+)*: This is a non-capturing group (indicated by (?: ... )) that matches zero or more sequences of a hyphen followed by one or more alphanumeric characters. The asterisk * allows for any number of these sequences, including none, enabling the pattern to match strings with multiple hyphen-separated segments.

Overall, the pattern is designed to match strings that start with "Breadcrumb." and are followed by a slug-like structure, which is commonly used in URLs and identifiers. 

Examples of strings that would match this pattern include "Breadcrumb.item", "Breadcrumb.item-name", and "Breadcrumb.item1-2-3".